### PR TITLE
Switch to xspec.io domain

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+xspec.io


### PR DESCRIPTION
Once the DNS record has been added for

`CNAME xpec.io. xpec.github.io.`

we can merge the CNAME record for Github pages